### PR TITLE
Fix legend item appearing on admin pages other than the registrations page Fixes #5

### DIFF
--- a/EED_Attendee_Mover.module.php
+++ b/EED_Attendee_Mover.module.php
@@ -290,17 +290,20 @@ class EED_Attendee_Mover extends EED_Module
      */
     public static function reg_admin_list_legend(array $items)
     {
-        // insert attendee_mover icon before the "approved_status" icon
-        $items = EEH_Array::insert_into_array(
-            $items,
-            array(
-                'attendee_mover' => array(
-                    'class' => 'dashicons dashicons-controls-repeat',
-                    'desc'  => esc_html__('Change Event/Ticket Selection', 'event_espresso'),
+        $screen = get_current_screen();
+        if ($screen instanceof WP_Screen && $screen->id === 'event-espresso_page_espresso_registrations') {
+            // insert attendee_mover icon before the "approved_status" icon
+            $items = EEH_Array::insert_into_array(
+                $items,
+                array(
+                    'attendee_mover' => array(
+                        'class' => 'dashicons dashicons-controls-repeat',
+                        'desc'  => esc_html__('Change Event/Ticket Selection', 'event_espresso'),
+                    ),
                 ),
-            ),
-            'approved_status'
-        );
+                'approved_status'
+            );
+        }
         return $items;
     }
 


### PR DESCRIPTION
## Problem this Pull Request solves
Fixes #5 

## How has this been tested
browser based monkey testing

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
