### PR TITLE
Allow for new_params.where to be an empty array.

### DIFF
--- a/scripts/attendee-mover-event-selector.js
+++ b/scripts/attendee-mover-event-selector.js
@@ -26,7 +26,7 @@ function EE_Attendee_Mover_Event_Select2( data_interface_args ) {
 			( params.page - 1 ) * this.items_per_page,
 			this.items_per_page,
 		];
-		if ( typeof new_params.where === 'undefined' ) {
+		if( typeof new_params.where === 'undefined' || new_params.where.length === 0 ) {
 			new_params.where = {};
 		}
 		var search_term = params.term || '';


### PR DESCRIPTION
If you want to show expired events on the attendee mover add-on we advise that you set the default where parameters to an empty array in the docs:

https://eventespresso.com/wiki/eea-attendee-mover/#customizations

(Note I've edited the code in that section to has at least 1 element in the array but is was just `return array();` previously)

Problem is in the attendee mover JS file for the event select2 params which checked if where was undefined, but if was an empty array (like in the case of the above) where was set to a standard array rather than an array of objects and select2 ignored the EVT_name value from that array.

## How has this been tested
Add this snippet to your site:

```
add_filter(
    'FHEE__AttendeeMover_form_SelectEvent__generate__where_parameters',
    function() {
        return array();
    }
);
```

Using master of the attendee mover, move a registration and on the event selection, search for an event. Note that ALL events are returned rather than just ones matching your input. If you check the REST request you'll see there's no EVT_name set - https://monosnap.com/file/vPva5TGcwCrnxIzaeGLtGmFQlBYdSr

Repeat the above using this branch (don't forget to hard refresh the attendee mover page first), you should see results that match your string and if you check the REST request again you'll see EVT_name is set.

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
