### PR TITLE
Add form name to exception. 

### DIFF
--- a/form/SelectTicket.php
+++ b/form/SelectTicket.php
@@ -157,6 +157,7 @@ class SelectTicket extends Step
                 $existing_ticket_ID = $registration->ticket_ID();
                 if ($TKT_ID === $existing_ticket_ID) {
                     throw new InvalidFormSubmissionException(
+                        $this->form_name,
                         esc_html__(
                             'Registrations can not be moved if you select the exact same ticket that the registration already has! Please select a different ticket.',
                             'event_espresso'


### PR DESCRIPTION
This fixes #11 and just adds the form name to the exception thrown by the attendee mover add-on.

There will still be a fatal error when working through this, see: https://github.com/eventespresso/event-espresso-core/pull/1201

## How has this been tested
See #10 

Move an attendee onto the same ticket they are already on and view the error thrown, before this change it shows a form is missing because the form name isn't being passed to it.

The fatal will still be thrown until 1201 is merged but this change stops the error showing that the form name is missing.

Assigning to Brent as its related to a couple of tickets that are now assigned to him, so this make more sense with those.

## Checklist

* [x ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
