### PR TITLE
Use the name() method to pull the form_name value.

### DIFF
--- a/form/SelectTicket.php
+++ b/form/SelectTicket.php
@@ -157,7 +157,7 @@ class SelectTicket extends Step
                 $existing_ticket_ID = $registration->ticket_ID();
                 if ($TKT_ID === $existing_ticket_ID) {
                     throw new InvalidFormSubmissionException(
-                        $this->form_name,
+                        $this->form()->name(),
                         esc_html__(
                             'Registrations can not be moved if you select the exact same ticket that the registration already has! Please select a different ticket.',
                             'event_espresso'


### PR DESCRIPTION
Fixes #13 

In #12 I added the form name to the exception thrown when you select the same ticket the registration is already on and used completely the wrong method (or in this case property) to get it!

## How has this been tested
Move a registration onto the same ticket it is already on, you should see a notice on the page stating:

>Registrations can not be moved if you select the exact same ticket that the registration already has! Please select a different ticket.

Now check your error logs and confirm there's no notice related to a form name.

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
