### PR TITLE
Add 'Re-apply promotions' option to the attendee mover confirmation step

### DIFF
--- a/form/Complete.php
+++ b/form/Complete.php
@@ -123,7 +123,7 @@ class Complete extends Step
         $new_registration = $this->registry->BUS->execute(
             $this->registry->create(
                 'EventEspresso\AttendeeMover\services\commands\MoveAttendeeCommand',
-                array($old_registration, $new_ticket, $this->notify())
+                array($old_registration, $new_ticket, $this->notify(), $this->copyPromos())
             )
         );
         if (! $new_registration instanceof EE_Registration) {

--- a/form/Step.php
+++ b/form/Step.php
@@ -55,6 +55,10 @@ abstract class Step extends SequentialStepForm
      */
     protected $notify;
 
+    /**
+     * @var bool $copyPromos
+     */
+    protected $copyPromos;
 
     /**
      * SequentialStepForm constructor
@@ -94,12 +98,14 @@ abstract class Step extends SequentialStepForm
         $this->EVT_ID = $this->getEventId();
         $this->TKT_ID = $this->getTicketId();
         $this->notify = $this->getNotify();
+        $this->copyPromos = $this->getCopyPromos();
         $this->addRedirectArgs(
             array(
                 '_REG_ID'   => $this->REG_ID,
                 'EVT_ID'    => $this->EVT_ID,
                 'TKT_ID'    => $this->TKT_ID,
                 'ee-notify' => $this->notify,
+                'ee-copy-promos' => $this->copyPromos,
             )
         );
         $this->addFormActionArgs(
@@ -108,6 +114,7 @@ abstract class Step extends SequentialStepForm
                 'EVT_ID'    => $this->EVT_ID,
                 'TKT_ID'    => $this->TKT_ID,
                 'ee-notify' => $this->notify,
+                'ee-copy-promos' => $this->copyPromos,
             )
         );
     }
@@ -238,6 +245,37 @@ abstract class Step extends SequentialStepForm
     public function setNotify($notify = true)
     {
         $this->notify = filter_var($notify, FILTER_VALIDATE_BOOLEAN);
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function copyPromos()
+    {
+        return $this->copyPromos;
+    }
+
+
+    /**
+     * @return bool
+     * @throws ReflectionException
+     * @throws EE_Error
+     */
+    public function getCopyPromos()
+    {
+        $request = $this->registry->load_core('Request');
+        $this->setCopyPromos($request->get('ee-copy-promos', false));
+        return $this->copyPromos;
+    }
+
+
+    /**
+     * @param bool $notify
+     */
+    public function setCopyPromos($copyPromos = true)
+    {
+        $this->copyPromos = filter_var($copyPromos, FILTER_VALIDATE_BOOLEAN);
     }
 
 

--- a/form/VerifyChanges.php
+++ b/form/VerifyChanges.php
@@ -7,6 +7,7 @@ use EE_Error;
 use EE_Form_Section_HTML;
 use EE_Form_Section_Proper;
 use EE_Registry;
+use EEM_Line_Item;
 use EventEspresso\core\exceptions\EntityNotFoundException;
 use EventEspresso\core\exceptions\InvalidFormSubmissionException;
 use EventEspresso\core\libraries\form_sections\form_handlers\FormHandler;
@@ -86,97 +87,128 @@ class VerifyChanges extends Step
         $th4 = esc_html__('New Event', 'event_espresso');
         $th5 = esc_html__('New Ticket', 'event_espresso');
         $th6 = esc_html__('Price Change', 'event_espresso');
-        $this->setForm(
-            new \EE_Form_Section_Proper(
-                array(
-                    'name'            => $this->slug(),
-                    'layout_strategy' => new \EE_Div_Per_Section_Layout(),
-                    'subsections'     => array(
-                        'changes'                     => new EE_Form_Section_HTML(
-                            \EEH_HTML::table(
-                                \EEH_HTML::thead(
-                                    \EEH_HTML::tr(
-                                        // \EEH_HTML::th( $th1 ) .
-                                        \EEH_HTML::th($th2) .
-                                        \EEH_HTML::th($th3) .
-                                        \EEH_HTML::th($th4) .
-                                        \EEH_HTML::th($th5) .
-                                        \EEH_HTML::th($th6)
+        $form = new \EE_Form_Section_Proper(
+            array(
+                'name'            => $this->slug(),
+                'layout_strategy' => new \EE_Div_Per_Section_Layout(),
+                'subsections'     => array(
+                    'changes'                     => new EE_Form_Section_HTML(
+                        \EEH_HTML::table(
+                            \EEH_HTML::thead(
+                                \EEH_HTML::tr(
+                                    // \EEH_HTML::th( $th1 ) .
+                                    \EEH_HTML::th($th2) .
+                                    \EEH_HTML::th($th3) .
+                                    \EEH_HTML::th($th4) .
+                                    \EEH_HTML::th($th5) .
+                                    \EEH_HTML::th($th6)
+                                )
+                            ) .
+                            \EEH_HTML::tbody(
+                                \EEH_HTML::tr(
+                                    \EEH_HTML::td(
+                                        $old_event_name,
+                                        '',
+                                        'am-old-event-name-td',
+                                        '',
+                                        'data-th="' . $th2 . '"'
+                                    ) .
+                                    \EEH_HTML::td(
+                                        $old_ticket_name_and_info,
+                                        '',
+                                        'am-old-ticket-name-td',
+                                        '',
+                                        'data-th="' . $th3 . '"'
+                                    ) .
+                                    \EEH_HTML::td(
+                                        $new_event_name,
+                                        '',
+                                        'am-new-event-name-td',
+                                        '',
+                                        'data-th="' . $th4 . '"'
+                                    ) .
+                                    \EEH_HTML::td(
+                                        $new_ticket->name_and_info(),
+                                        '',
+                                        'am-new-ticket-name-td',
+                                        '',
+                                        'data-th="' . $th5 . '"'
+                                    ) .
+                                    \EEH_HTML::td(
+                                        \EEH_Template::format_currency($price_change),
+                                        '',
+                                        'am-price-change-td jst-rght' . $price_class,
+                                        '',
+                                        'data-th="' . $th6 . '"'
                                     )
-                                ) .
-                                \EEH_HTML::tbody(
-                                    \EEH_HTML::tr(
-                                        \EEH_HTML::td(
-                                            $old_event_name,
-                                            '',
-                                            'am-old-event-name-td',
-                                            '',
-                                            'data-th="' . $th2 . '"'
-                                        ) .
-                                        \EEH_HTML::td(
-                                            $old_ticket_name_and_info,
-                                            '',
-                                            'am-old-ticket-name-td',
-                                            '',
-                                            'data-th="' . $th3 . '"'
-                                        ) .
-                                        \EEH_HTML::td(
-                                            $new_event_name,
-                                            '',
-                                            'am-new-event-name-td',
-                                            '',
-                                            'data-th="' . $th4 . '"'
-                                        ) .
-                                        \EEH_HTML::td(
-                                            $new_ticket->name_and_info(),
-                                            '',
-                                            'am-new-ticket-name-td',
-                                            '',
-                                            'data-th="' . $th5 . '"'
-                                        ) .
-                                        \EEH_HTML::td(
-                                            \EEH_Template::format_currency($price_change),
-                                            '',
-                                            'am-price-change-td jst-rght' . $price_class,
-                                            '',
-                                            'data-th="' . $th6 . '"'
-                                        )
-                                    )
-                                ),
-                                'eea-attendee-mover-info-table-' . $this->slug(),
-                                'eea-attendee-mover-info-table ee-responsive-table'
-                            )
-                        ),
-                        'notifications'               => new \EE_Form_Section_Proper(
-                            array(
-                                'layout_strategy' => new \EE_Admin_Two_Column_Layout(),
-                                'subsections'     => array(
-                                    'trigger_send' => new \EE_Yes_No_Input(
-                                        array(
-                                            'html_label_text' => esc_html__('Trigger Notifications?', 'event_espresso'),
-                                            'html_help_text'  => esc_html__(
-                                                'If "Yes" is selected, then notifications regarding these changes will be sent to the registration\'s contact (for example: Registration Approved (Event Admin context) + Registration Approved (Primary Registrant context), etc).',
-                                                'event_espresso'
-                                            ),
-                                        )
-                                    ),
-                                    '1'            => new EE_Form_Section_HTML(\EEH_HTML::br()),
-                                ),
-                            )
-                        ),
-                        $this->slug() . '-submit-btn' => $this->generateSubmitButton(),
-                        $this->slug() . '-cancel-btn' => $this->generateCancelButton(),
-                        '2'                           => new EE_Form_Section_HTML(\EEH_HTML::br(2)),
-                        'EVT_ID'                      => new \EE_Fixed_Hidden_Input(
-                            array('default' => $this->getEventId())
-                        ),
-                        'TKT_ID'                      => new \EE_Fixed_Hidden_Input(
-                            array('default' => $this->getTicketId())
-                        ),
+                                )
+                            ),
+                            'eea-attendee-mover-info-table-' . $this->slug(),
+                            'eea-attendee-mover-info-table ee-responsive-table'
+                        )
                     ),
-                )
+                    'notifications'               => new \EE_Form_Section_Proper(
+                        array(
+                            'layout_strategy' => new \EE_Admin_Two_Column_Layout(),
+                            'subsections'     => array(
+                                'trigger_send' => new \EE_Yes_No_Input(
+                                    array(
+                                        'html_label_text' => esc_html__('Trigger Notifications?', 'event_espresso'),
+                                        'html_help_text'  => esc_html__(
+                                            'If "Yes" is selected, then notifications regarding these changes will be sent to the registration\'s contact (for example: Registration Approved (Event Admin context) + Registration Approved (Primary Registrant context), etc).',
+                                            'event_espresso'
+                                        ),
+                                    )
+                                ),
+                                '1'            => new EE_Form_Section_HTML(\EEH_HTML::br()),
+                            ),
+                        )
+                    ),
+                    $this->slug() . '-submit-btn' => $this->generateSubmitButton(),
+                    $this->slug() . '-cancel-btn' => $this->generateCancelButton(),
+                    '2'                           => new EE_Form_Section_HTML(\EEH_HTML::br(2)),
+                    'EVT_ID'                      => new \EE_Fixed_Hidden_Input(
+                        array('default' => $this->getEventId())
+                    ),
+                    'TKT_ID'                      => new \EE_Fixed_Hidden_Input(
+                        array('default' => $this->getTicketId())
+                    ),
+                ),
             )
         );
+
+        $line_items_where = array(
+            'TXN_ID'     => $registration->transaction_ID(),
+            'OBJ_type'   => EEM_Line_Item::OBJ_TYPE_PROMOTION,
+        );
+        if (EEM_Line_Item::instance()->exists(array($line_items_where))
+            && class_exists('EED_Promotions')
+        ) {
+            $form->add_subsections(
+                array(
+                    'promotions'               => new \EE_Form_Section_Proper(
+                        array(
+                            'layout_strategy' => new \EE_Admin_Two_Column_Layout(),
+                            'subsections'     => array(
+                                'copy_promotions' => new \EE_Yes_No_Input(
+                                    array(
+                                        'html_label_text' => esc_html__('Re-apply Promotions?', 'event_espresso'),
+                                        'html_help_text'  => esc_html__(
+                                            'If "Yes" is selected, then any applicible promotions applied to the transaction will be copied to include the new registration.',
+                                            'event_espresso'
+                                        ),
+                                    )
+                                ),
+                                '1'            => new EE_Form_Section_HTML(\EEH_HTML::br()),
+                            ),
+                        )
+                    )
+                ),
+                'notifications',
+                false
+            );
+        }
+        $this->setForm($form);
         return $this->form();
     }
 

--- a/form/VerifyChanges.php
+++ b/form/VerifyChanges.php
@@ -229,7 +229,19 @@ class VerifyChanges extends Step
         } else {
             add_filter('FHEE__EED_Messages___maybe_registration__deliver_notifications', '__return_false', 15);
         }
-        $this->addRedirectArgs(array('ee-notify' => $this->notify));
+
+        if (isset($valid_data['promotions'], $valid_data['promotions']['copy_promotions'])
+            && $valid_data['promotions']['copy_promotions'] === true
+        ) {
+            // Copy promotions
+            $this->setCopyPromos();
+        }
+        $this->addRedirectArgs(
+            array(
+                'ee-notify' => $this->notify,
+                'ee-copy-promos' => $this->copyPromos
+            )
+        );
         $this->setRedirectTo(SequentialStepForm::REDIRECT_TO_NEXT_STEP);
         return true;
     }

--- a/services/commands/MoveAttendeeCommand.php
+++ b/services/commands/MoveAttendeeCommand.php
@@ -49,11 +49,13 @@ class MoveAttendeeCommand extends Command implements CommandRequiresCapCheckInte
     public function __construct(
         EE_Registration $old_registration,
         EE_Ticket $new_ticket,
-        $trigger_notifications
+        $trigger_notifications,
+        $copy_promotions
     ) {
         $this->registration = $old_registration;
         $this->ticket = $new_ticket;
         $this->trigger_notifications = filter_var($trigger_notifications, FILTER_VALIDATE_BOOLEAN);
+        $this->copy_promotions = filter_var($copy_promotions, FILTER_VALIDATE_BOOLEAN);
     }
 
 
@@ -96,5 +98,14 @@ class MoveAttendeeCommand extends Command implements CommandRequiresCapCheckInte
     public function triggerNotifications()
     {
         return $this->trigger_notifications;
+    }
+
+
+    /**
+     * @return bool
+     */
+    public function copyPromotions()
+    {
+        return $this->copy_promotions;
     }
 }

--- a/services/commands/MoveAttendeeCommandHandler.php
+++ b/services/commands/MoveAttendeeCommandHandler.php
@@ -120,6 +120,11 @@ class MoveAttendeeCommandHandler extends CommandHandler
         $this->copy_registration_service->copyPaymentDetails($new_registration, $old_registration);
         // and additional data from old registration, like reg form question answers
         $this->copy_registration_service->copyRegistrationDetails($new_registration, $old_registration);
+        // copy promotion line items if requested
+        if ($command->copyPromotions()) {
+            // move/copy over promotion line items
+            $this->copy_registration_service->copyPromotionLineItems($new_registration, $old_registration);
+        }
         // now cancel original registration and it's ticket line item
         $this->cancel_registration_service->cancelRegistrationAndTicketLineItem($old_registration, false);
         // manually increment ticket sold count for new ticket if registration is approved


### PR DESCRIPTION
I don't consider this finished yet, but I mentioned it in Slack and Brent offered to take a look and give feedback so here goes. I'll add details in this PR as the other one related to this in core is a single change to add a method to the service and its for functionality in this add-on.

Most of this seems fine, adding the option etc I don't have a problem with, however, the call to the new `copyPromotionLineItems()` method feels a little fragile and I'm not sure what the best way to avoid/reduce that is.

The call relies on the promotions add-on and I know I could just use `class_exists()` to make sure the promotions add-on is available before running it (including doing so within the method itself) or even move that method away from using functions in the promotions add-on directly but I get the feeling the service should be added from within the promotions add-on itself rather than patching it into core, right?

I don't know how the best way to go about doing that so any pointers appreciated :)

Would I need to add dependency injection to the promotions add-on and add a `/domain/services/line_items/` service for example or something completely different?


## Problem this Pull Request solves
It applies the promotion set on the 'original' registration to the 'new' one, without incrementing the 'usage' value of that add-on (as the original usage would have done so).

The changes in this specific PR don't do much other than add the visuals for that and the option not to apply promotions.

## How has this been tested
Register onto an event and use a promotion during checkout for whatever value/percentage. Finalize.

Move the registration onto anther ticket/event and select to re-apply promotions, the 'new' registration should have the promotion applied.

(Note this intentionally skips any/all checks for promotion being valid etc and just applies it)

## Checklist

* [ ] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [ ] User input is adequately validated and sanitized
* [ ] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [ ] My code is tested.
* [ ] My code follows the Event Espresso code style.
* [ ] My code has proper inline documentation.
