### PR TITLE
added action hook after the handler has completed

### DIFF
--- a/services/commands/MoveAttendeeCommandHandler.php
+++ b/services/commands/MoveAttendeeCommandHandler.php
@@ -98,7 +98,7 @@ class MoveAttendeeCommandHandler extends CommandHandler
     public function handle(CommandInterface $command)
     {
         /** @var MoveAttendeeCommand $command */
-        if (! $command instanceof MoveAttendeeCommand) {
+        if (!$command instanceof MoveAttendeeCommand) {
             throw new InvalidEntityException(get_class($command), 'MoveAttendeeCommand');
         }
         $old_registration = $command->registration();
@@ -137,6 +137,14 @@ class MoveAttendeeCommandHandler extends CommandHandler
         $this->update_registration_service->updateRegistrationAndTransaction($command->registration());
         // tag registrations for identification purposes
         $this->addExtraMeta($old_registration, $new_registration, $new_ticket);
+
+        // hook to allow other addons to do stuff with the new registration
+        do_action(
+            'AHEE__MoveAttendeeCommandHandler__handle__after',
+            $new_registration,
+            $old_registration,
+            $new_ticket
+        );
         return $new_registration;
     }
 

--- a/services/commands/MoveAttendeeCommandHandler.php
+++ b/services/commands/MoveAttendeeCommandHandler.php
@@ -98,7 +98,7 @@ class MoveAttendeeCommandHandler extends CommandHandler
     public function handle(CommandInterface $command)
     {
         /** @var MoveAttendeeCommand $command */
-        if (!$command instanceof MoveAttendeeCommand) {
+        if (! $command instanceof MoveAttendeeCommand) {
             throw new InvalidEntityException(get_class($command), 'MoveAttendeeCommand');
         }
         $old_registration = $command->registration();
@@ -140,7 +140,7 @@ class MoveAttendeeCommandHandler extends CommandHandler
 
         // hook to allow other addons to do stuff with the new registration
         do_action(
-            'AHEE__MoveAttendeeCommandHandler__handle__after',
+            'AHEE__AttendeeMover_services_commands_MoveAttendeeCommandHandler__handle__after',
             $new_registration,
             $old_registration,
             $new_ticket


### PR DESCRIPTION

<!-- Thanks for your pull request.  Comments within these type of tags will be hidden and not show up when you submit your pull request -->
<!-- Please answer the following questions in order to expediate acceptance -->

## Problem this Pull Request solves
<!-- Please describe your changes in the context of the problem they solve -->
There are no hooks within the command handler to allow other plugins to work alongside the attendee mover.


## How has this been tested
<!-- Please describe in detail how you tested your changes and how testing can be reproduced -->
<!-- Include details of your testing environment, and tests ran to see how your changes affect other areas of code -->
<!-- Include any notes about automated tests you've written for this pull request.  Pull requests with automated tests are preferred. -->

## Checklist

* [x] I have read the documentation relating to systems affected by this pull request, see https://github.com/eventespresso/event-espresso-core/tree/master/docs
* [x] User input is adequately validated and sanitized
* [x] all publicly displayed strings are internationalized (usually using `esc_html__()`, see https://codex.wordpress.org/I18n_for_WordPress_Developers)
* [x] My code is tested.
* [x] My code follows the Event Espresso code style.
* [x] My code has proper inline documentation.
